### PR TITLE
breaks dockerfile to fail GH action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.13-slim
 WORKDIR /app
 
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txtttt
 
 COPY . .
 


### PR DESCRIPTION
Inside Dockerfile, changed one line to fail the GitHub Action

Original: 
```
RUN pip install --no-cache-dir -r requirements.txt
```

Now:
```
RUN pip install --no-cache-dir -r requirements.txtttt
```